### PR TITLE
update node.js version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.1.0-slim
+FROM node:4.3.1-slim
 ENV REFRESHED_AT 2016_02_20
 
 RUN wget https://github.com/tantaman/Strut/archive/master.tar.gz -O ./Strut.tar.gz \


### PR DESCRIPTION
Node.js version 4.3.1-slim seems to work also.  You can test it with my testing container: cguenther/strut:latest-tantaman.

Version 5.x seems to raise a build error. I am not able to debug this, due to my knowledge lack for js.
Node.js 5.6-slim build failure:
https://hub.docker.com/r/cguenther/strut/builds/b4xcojgleitsk879vhdbucd/
